### PR TITLE
Typo fixed

### DIFF
--- a/src/joiValidationStrategy.js
+++ b/src/joiValidationStrategy.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import set from 'lodash.set';
-import isEmpty from 'lodash.isEmpty';
+import isEmpty from 'lodash.isempty';
 import {hydrate} from './utils';
 import invariant from 'invariant';
 


### PR DESCRIPTION
Fixing the error:

```
Error: Cannot find module 'lodash.isEmpty' from '/.../node_modules/joi-validation-strategy/lib'
```
