### PR TITLE
Fixes #7; Babel 6 compatible npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.2",
   "description": "Joi validation strategy for react-validation-mixin",
   "main": "./lib/joiValidationStrategy.js",
+  "files": [
+    "src",
+    "lib"
+  ],
   "scripts": {
     "build": "npm run lint && npm run build:lib",
     "build:lib": "babel src --out-dir lib",


### PR DESCRIPTION
Fixes #7.

Notes: You'll have to republish the existing npm package, or publish a new one.

You may also want to do the same thing to the related react-validation-mixin package.

Thanks!
